### PR TITLE
Transaction fix

### DIFF
--- a/policies_test.go
+++ b/policies_test.go
@@ -384,7 +384,7 @@ func TestHostRoutingBatch(t *testing.T) {
 }
 
 // The cluster should be created with the following tags:
-//--tserver_flags="cql_nodelist_refresh_interval_secs=10" --master_flags="tserver_unresponsive_timeout_ms=10000"
+//--tserver_flags="cql_nodelist_refresh_interval_secs=8" --master_flags="tserver_unresponsive_timeout_ms=10000"
 func TestCreateDropTable(t *testing.T) {
 	//change the ip address according to the cluster
 	cluster := NewCluster("127.0.0.1")

--- a/session.go
+++ b/session.go
@@ -1166,7 +1166,7 @@ func (q *Query) shouldPrepare() bool {
 		}
 	}
 	switch stmtType {
-	case "select", "insert", "update", "delete", "batch":
+	case "select", "insert", "update", "delete", "batch", "transaction", "start":
 		return true
 	}
 	return false

--- a/session.go
+++ b/session.go
@@ -1160,13 +1160,13 @@ func (q *Query) shouldPrepare() bool {
 	if n := strings.IndexFunc(stmt, unicode.IsSpace); n >= 0 {
 		stmtType = strings.ToLower(stmt[:n])
 	}
-	if stmtType == "begin" {
+	if stmtType == "begin" || stmtType == "start" {
 		if n := strings.LastIndexFunc(stmt, unicode.IsSpace); n >= 0 {
 			stmtType = strings.ToLower(stmt[n+1:])
 		}
 	}
 	switch stmtType {
-	case "select", "insert", "update", "delete", "batch", "transaction", "start":
+	case "select", "insert", "update", "delete", "batch", "transaction", "commit":
 		return true
 	}
 	return false

--- a/yb_transaction_test.go
+++ b/yb_transaction_test.go
@@ -1,0 +1,82 @@
+package gocql
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+//Test of Transactions supported by YCQL
+func Test_YB_Trsansaction(t *testing.T) {
+	//change the ip address according to the cluster
+	cluster := NewCluster("127.0.0.1")
+	cluster.Timeout = 5 * time.Second
+
+	session, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	//create keyspace "example"
+	createStmt := "CREATE Keyspace IF NOT EXISTS example"
+	if err := session.Query(createStmt).Exec(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test table "test1".
+	var createStmtt1 = "CREATE TABLE example.test1 (test1_id bigint PRIMARY KEY, count bigint) WITH default_time_to_live = 0 AND transactions = {'enabled': 'true'}"
+	if err := session.Query(createStmtt1).Exec(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test table "test2".
+	var createStmtt2 = "CREATE TABLE example.test2 (test2_id text PRIMARY KEY, count bigint) WITH default_time_to_live = 0 AND transactions = {'enabled': 'true'}"
+	if err := session.Query(createStmtt2).Exec(); err != nil {
+		t.Fatal(err)
+	}
+
+	insertValues := make([]interface{}, 0)
+	insertValues = append(insertValues, 1, 1, "1", 1)
+
+	// Insert a row in table "test1" and "test2" as a single transaction
+	s := fmt.Sprintf(`START TRANSACTION;
+	INSERT INTO %[1]s.test1(test1_id, count) values(?,?);
+	INSERT INTO %[1]s.test2(test2_id, count) values(?,?);;
+	COMMIT;`, "example")
+	if err = session.Query(s).Bind(insertValues...).Exec(); err != nil {
+		t.Fatal(err)
+	}
+
+	values := make([]interface{}, 0)
+	values = append(values, 100, 1, 3, 100, "1", 3)
+
+	queryBuilder := "BEGIN TRANSACTION UPDATE example.test1 USING TTL ? SET count = count + 1 WHERE test1_id = ? IF count + 1 <= ? ELSE ERROR; UPDATE example.test2 USING TTL ? SET count = count + 1 WHERE test2_id = ? IF count + 1 <= ? ELSE ERROR; END TRANSACTION;"
+	if err = session.Query(queryBuilder).Bind(values...).Exec(); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(5 * time.Second)
+	selectQry1 := session.Query("select count from example.test1 where test1_id = ?", 1)
+	var c int
+	selectQry1.Scan(&c)
+	assertEqual(t, "count value", 2, c)
+
+	selectQry2 := session.Query("select count from example.test2 wherez ?", '1')
+	selectQry2.Scan(&c)
+	assertEqual(t, "count value", 2, c)
+
+	queryBuilder = "START TRANSACTION; UPDATE example.test1 USING TTL ? SET count = count + 1 WHERE test1_id = ? IF count + 1 <= ? ELSE ERROR; UPDATE example.test2 USING TTL ? SET count = count + 1 WHERE test2_id = ? IF count + 1 <= ? ELSE ERROR; COMMIT;"
+	if err = session.Query(queryBuilder).Bind(values...).Exec(); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(5 * time.Second)
+	selectQry1 = session.Query("select count from example.test1 where test1_id = ?", 1)
+	selectQry1.Scan(&c)
+	assertEqual(t, "count value", 3, c)
+
+	selectQry2 = session.Query("select count from example.test2 where test2_id = ?", '1')
+	selectQry2.Scan(&c)
+	assertEqual(t, "count value", 3, c)
+}


### PR DESCRIPTION
Fixes [DB-7059](https://yugabyte.atlassian.net/browse/DB-7095) [#18045](https://github.com/yugabyte/yugabyte-db/issues/18045)

**DESCRIPTION**
Executing transactions with Bind statements as a single query, for example : 
```
queryBuilder := "BEGIN TRANSACTION stmt1; stmt2;  END TRANSACTION;"
session.Query(queryBuilder).Bind(<values>).Exec();
```
This was failing with the following error : 
` Invalid Arguments. Bind variable at position 2 not found.`

**Fix**
gocql prepares all DMLs (especially Bind statements) before executing them. To find out whether a statement is a DML or not it simple uses a function `shouldPrepare()`. Since Cassandra does not support `transactions` this method was sending `false` due to which the query was not getting prepared which caused the above error. Fixing `shouldPrepare()` to send `true` for transactions as well fixed the issue.

**Test**
Added a new test for `Transactions`.
Tested by running `go test -v`