### PR TITLE
Print error code along with error message

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -109,7 +109,7 @@ func (e errorFrame) Message() string {
 }
 
 func (e errorFrame) Error() string {
-	return e.Message()
+	return "code=" + fmt.Sprintf("%x", e.Code()) + "; message=" + e.Message()
 }
 
 func (e errorFrame) String() string {

--- a/yb_transaction_test.go
+++ b/yb_transaction_test.go
@@ -83,9 +83,9 @@ func Test_YB_Trsansaction(t *testing.T) {
 
 	queryBuilder = "START TRANSACTION; UPDATE example.test1 USING TTL ? SET count = count + 1 WHERE test1_id = ? IF count + 1 <= ? ELSE ERROR; UPDATE example.test2 USING TTL ? SET count = count + 1 WHERE test2_id = ? IF count + 1 <= ? ELSE ERROR; COMMIT;"
 	if err = session.Query(queryBuilder).Bind(values...).Exec(); err != nil {
-		str := "code=2200"
-		errnew := fmt.Errorf(str)
-		assertEqual(t, "Error", errnew.Error(), strings.Split(err.Error(), ";")[0])
+		errorStr := strings.Split(err.Error(), ";")
+		assertEqual(t, "Error", "code=2200", errorStr[0])
+		assertEqual(t, "Error", " message=Execution Error. Condition on table test1 was not satisfied.", strings.Split(errorStr[1], "\n")[0])
 	}
 
 	time.Sleep(5 * time.Second)

--- a/yb_transaction_test.go
+++ b/yb_transaction_test.go
@@ -83,9 +83,9 @@ func Test_YB_Trsansaction(t *testing.T) {
 
 	queryBuilder = "START TRANSACTION; UPDATE example.test1 USING TTL ? SET count = count + 1 WHERE test1_id = ? IF count + 1 <= ? ELSE ERROR; UPDATE example.test2 USING TTL ? SET count = count + 1 WHERE test2_id = ? IF count + 1 <= ? ELSE ERROR; COMMIT;"
 	if err = session.Query(queryBuilder).Bind(values...).Exec(); err != nil {
-		str := "Execution Error. Condition on table test1 was not satisfied."
+		str := "code=2200"
 		errnew := fmt.Errorf(str)
-		assertEqual(t, "Error", errnew.Error(), strings.Split(err.Error(), "\n")[0])
+		assertEqual(t, "Error", errnew.Error(), strings.Split(err.Error(), ";")[0])
 	}
 
 	time.Sleep(5 * time.Second)


### PR DESCRIPTION
Fixes : [DB-7729](https://yugabyte.atlassian.net/browse/DB-7729)

The error returned from query.Exec() is of type gocql.errorFrame for which there's no way to extract code from the error.

This change resolves above issue, now err.Error() will return error message as well as the error code separated by a semi-colon. 

**Test** :
`go test -v`